### PR TITLE
Added ttf-dejavu to install commands to ensure a font is added to the…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
-# Date: 2016-08-11
+# Date: 2017-02-21
 FROM base/archlinux:latest
 MAINTAINER Christian Berger "christian.berger@gu.se"
 
@@ -43,7 +43,8 @@ RUN pacman --noconfirm -S \
     opencv \
     python2 \
     qt4 \
-    qwt5
+    qwt5 \
+    ttf-dejavu
 
 RUN pacman --noconfirm -S gdb
 


### PR DESCRIPTION
To ensure a font is installed in the archlinux docker image, I've added the ttf-dejavu font package to be installed upon pulling the archlinux docker image. 

Not sure if I should update the date or, please provide feedback if anything needs to be fixed.